### PR TITLE
Allow backup via adb

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="net.bierbaumer.otp_authenticator">
 
     <application
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
I regularly flash the OS on my phone, wiping all data. I use `adb backup` to ensure my app data is backed up. This will allow otp-authenticator to be backed up and restored. Of course, handling the backup securely is up to the user to do correctly ;-)
