### PR TITLE
Fix status bar background on Lollipop+

### DIFF
--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -4,7 +4,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryDark</item>
         <item name="windowActionModeOverlay">true</item>
     </style>
 </resources>


### PR DESCRIPTION
The transparent status bar coloring results in a weird-looking shadow on top of the toolbar. Setting it to colorPrimaryDark fixes it.

Before:
![](https://i.imgur.com/urTmDDb.png)

After:
![](https://i.imgur.com/ygdv91a.png)

Since the app has no navigation drawer, there is no need for the status bar to be transparent.
